### PR TITLE
Readdress #3 (Issue with LOAD=)

### DIFF
--- a/docs/instance.md
+++ b/docs/instance.md
@@ -1,5 +1,44 @@
 You create an instance of `APLProcess` using either `⎕NEW` or [`APLProcess.New`](shared-methods.md#new) as described in the [Creating and Starting APLProcess](./userguide.md#creating-and-starting-aplprocess). 
 
+## `APLProcess` and Dyalog APL Configuration Parameters
+Dyalog APL is customized using a set of configuration parameters. These may be defined in a number of ways, which take precedence as follows:
+
+* Command-line settings
+* Application configuration file settings
+* Environment variable settings
+* User configuration file settings
+* Settings in the registry section defined by the IniFile parameter (Windows only)
+* Built-in defaults
+
+A child process will inherit the environment variable settings from the parent process. To demonstrate this in a somewhat contrived manner, suppose you started Dyalog APL from a Linux command line as follows:
+
+```APL
+MAXWS=2GB dyalog MAXWS=1GB
+```
+The `MAXWS` to the left of dyalog is an environment variable and the `MAXWS` to the right of the dyalog is a command-line setting. The `MAXWS` in the started process will be `1GB` as command-line settings take precedence over environment variables.
+
+However, if you use `APLProcess` to start a child process, it will inherit the `2GB` environment variable setting.
+
+In the parent process:
+```APL
+      ]config MAXWS -origin
+┌─────┬────────────┬───┐
+│MAXWS│Command line│1GB│
+└─────┴────────────┴───┘
+      ]load APLProcess
+      p←APLProcess.New ''
+      p.Run
+```
+In the child process:
+```APL
+      ]config MAXWS -origin
+┌─────┬────────────────────┬───┐
+│MAXWS│Environment variable│2GB│
+└─────┴────────────────────┴───┘
+```
+In most cases, there is no issue with inheriting the parent's environment 
+variables. However, the `LOAD` and `LX` configuration settings present a potential problem in that they could start a recursive chain of events that would result in a universe-eating black hole. As such, if `APLProcess` detects `LOAD` and/or `LX` as environment variables in the parent process, it will remove them from the environment of the child process(es). You can specify `LOAD` and `LX` for the child process(es) using the [`Load`](#load) and [`Lx`](#lx) settings respectively or as a part of the [`Args`](#args) setting.
+
 ## Settings
 `APLProcess`'s settings can be provided as arguments to  `APLProcess.New` or `⎕NEW`. You can also specify settings in the `APLProcess` instance before launching the new process. When provided as arguments, the settings can be specified in two ways.
 

--- a/docs/instance.md
+++ b/docs/instance.md
@@ -36,6 +36,7 @@ In the child process:
 │MAXWS│Environment variable│2GB│
 └─────┴────────────────────┴───┘
 ```
+### Special Treatment of `LOAD` and `LX` Environment Variables.
 In most cases, there is no issue with inheriting the parent's environment 
 variables. However, the `LOAD` and `LX` configuration settings present a potential problem in that they could start a recursive chain of events that would result in a universe-eating black hole. As such, if `APLProcess` detects `LOAD` and/or `LX` as environment variables in the parent process, it will remove them from the environment of the child process(es). You can specify `LOAD` and `LX` for the child process(es) using the [`Load`](#load) and [`Lx`](#lx) settings respectively or as a part of the [`Args`](#args) setting.
 
@@ -84,14 +85,14 @@ variables. However, the `LOAD` and `LX` configuration settings present a potenti
 | Description | `Load` specifies the `LOAD` parameter for the child process.  `Load` specifies the workspace, folder, or file to be loaded and run by the child process. `Load`, if specified, overrides the workspace specified by `Ws`. |
 | Default | `''` |
 | Examples | `p.Load←'/home/user/myapp'` |
-| Notes | `APLProcess` will always set the `LOAD` command line parameter in order to not inherit the setting from the parent APL process.|
+| Notes | See [Special Treatment of LOAD and LX Environment Variables](#special-treatment-of-load-and-lx-environment-variables). |
 
 ### `Lx`
 |--|--|
 | Description | `Lx` specifies the `LX` parameter for the child process.  `Lx`, if specified, overrides `⎕LX` in the workspace, if a workspace is either specified by `Ws` or `Load`. |
 | Default | `''` which means that the child process will inherit the `LX` parameter, if any, set for the parent process. |
 | Examples | `p.Lx←'Start'` |
-| Notes | If `LX` is set for the parent process and `Lx` is not specified for the child process, the child process will inherit the parent's setting. This is likely to not be what you want.|
+| Notes | See [Special Treatment of LOAD and LX Environment Variables](#special-treatment-of-load-and-lx-environment-variables).|
 
 
 ### `OutFile`

--- a/docs/instance.md
+++ b/docs/instance.md
@@ -10,7 +10,7 @@ Dyalog APL is customized using a set of configuration parameters. These may be d
 * Settings in the registry section defined by the IniFile parameter (Windows only)
 * Built-in defaults
 
-A child process will inherit the environment variable settings from the parent process. To demonstrate this in a somewhat contrived manner, suppose you started Dyalog APL from a Linux command line as follows:
+A child process will inherit the environment variable settings from the parent process. To demonstrate this in a somewhat contrived manner, suppose you started Dyalog APL from a Linux/MacOS command line as follows:
 
 ```APL
 MAXWS=2GB dyalog MAXWS=1GB

--- a/source/APLProcess.dyalog
+++ b/source/APLProcess.dyalog
@@ -5,7 +5,7 @@
 
     ∇ r←Version
       :Access Public Shared
-      r←'APLProcess' '2.4.0' '2025-12-09'
+      r←'APLProcess' '2.4.1' '2026-01-22'
     ∇
 
     :Field Public Args←''
@@ -91,7 +91,7 @@
       :EndTrap
     ∇
 
-    ∇ Start(ws args rt);psi;pid;cmd;host;port;keyfile;exe;z;output
+    ∇ Start(ws args rt);psi;pid;cmd;host;port;keyfile;exe;z;output;suppressLx;suppressLoad;suppress
       (Ws Args)←ws args
      
       :If 0∊⍴RideInit ⍝ Always set RIDE_INIT so that started process does not inherit this process's setting
@@ -102,7 +102,11 @@
           args,←' RIDE_INIT="',RideInit,'" RIDE_SPAWNED=1'
       :EndIf
      
-      args,←' LOAD="',Load,'"' ⍝ always set LOAD as to not inherit this process's setting
+      (suppressLoad suppressLx)←1=source'LOAD' 'LX' ⍝ if LOAD or LX are environment variables for parent, suppress them for child processes
+     
+      :If ~0∊⍴Load
+          args,←' LOAD="',Load,'"'
+      :EndIf
      
       :If ~0∊⍴Lx
           args,←' LX="',Lx,'"'
@@ -122,15 +126,15 @@
           psi←⎕NEW Diagnostics.ProcessStartInfo,⊂Exe(ws,' ',args)
           psi.WindowStyle←Diagnostics.ProcessWindowStyle.Minimized
           psi.WorkingDirectory←WorkingDir
+          psi.UseShellExecute←0
      
           :If ~0∊⍴OutFile
-              psi.UseShellExecute←0        ⍝ this needs to be false to redirect IO (.NET Core defaults to false, .NET Framework defaults to true)
               psi.StandardOutputEncoding←Text.Encoding.UTF8
               psi.RedirectStandardOutput←1 ⍝ redirect standard output
-          :Else
-              psi.RedirectStandardOutput←0
-              psi.UseShellExecute←1
           :EndIf
+     
+          :If suppressLoad ⋄ {}psi.Environment.Remove⊂'LOAD' ⋄ :EndIf
+          :If suppressLx ⋄ {}psi.Environment.Remove⊂'LX' ⋄ :EndIf
      
           Proc←Diagnostics.Process.Start psi
      
@@ -140,6 +144,9 @@
           :EndIf
      
           cmd←(~0∊⍴WorkingDir)/'cd ',WorkingDir,'; '
+          suppress←suppressLoad/'unset LOAD; '
+          suppress,←suppressLx/'unset LX; '
+     
           :If IsSsh
               (host port keyfile exe)←Exe
               cmd,←args,' ',exe,' +s -q ',ws
@@ -147,7 +154,7 @@
           :Else
               z←⍕GetCurrentProcessId
               output←(1+×≢OutFile)⊃'/dev/null'OutFile
-              cmd,←'{ ',args,' ',Exe,' +s -q ',ws,' -c APLppid=',z,' </dev/null >',output,' 2>&1 & } ; echo $!'
+              cmd,←'{ ',suppress,args,' ',Exe,' +s -q ',ws,' -c APLppid=',z,' </dev/null >',output,' 2>&1 & } ; echo $!'
               pid←tonum⊃_SH cmd
               Proc.Id←pid
               Proc.HasExited←HasExited
@@ -618,6 +625,21 @@
     deb←{1↓¯1↓{⍵/⍨~'  '⍷⍵}' ',⍵,' '} ⍝ delete extraneous blanks
     part←{⍵⊆⍨~⍺{⍵∧⍺>+\⍵}' '=⍵} ⍝ partition first ⍺ sections
     nameClass←{⎕NC⊂,'⍵'} ⍝ name class of argument
+
+    ∇ r←source setting
+    ⍝ returns the source of a setting
+    ⍝ 0 - not defined
+    ⍝ 1 - environment variable
+    ⍝ 2 - command line
+    ⍝ 3 - windows registry
+    ⍝ 4 - configuration file
+      :Access public shared
+      :If 1<|≡setting
+          r←source¨setting
+      :Else
+          r←¯1+'not' 'env' 'com' 'reg'⍳⊂⎕C 3↑2⊃160⌶setting
+      :EndIf
+    ∇
 
     ∇ r←IsWin
       :Access public shared


### PR DESCRIPTION
This is a better treatment of the issue.

In this iteration we remove LOAD and/or LX from the child process environment if they are defined as environment variables in the parent process.